### PR TITLE
Satisfy auto-discovery on Mac

### DIFF
--- a/src/main/java/net/tlipinski/NovationImpulse49ExtensionDefinition.java
+++ b/src/main/java/net/tlipinski/NovationImpulse49ExtensionDefinition.java
@@ -78,12 +78,12 @@ public class NovationImpulse49ExtensionDefinition extends ControllerExtensionDef
          // list.add(new String[]{"Input Port 0", "Input Port 1"}, new String[]{"Output Port 0", "Output Port 1"});
       }
       else if (platformType == PlatformType.MAC) {
-         // TODO: Set the correct names of the ports for auto detection on Windows platform here
-         // and uncomment this when port names are correct.
-         // list.add(new String[]{"Input Port 0", "Input Port 1"}, new String[]{"Output Port 0", "Output Port 1"});
+         String[] inputPortNames = { "Impulse  Impulse ", "Impulse  Impulse MIDI In " };
+         String[] outputPortNames = { "Impulse  Impulse " };
+         list.add(inputPortNames, outputPortNames);
       }
       else if (platformType == PlatformType.LINUX) {
-         // TODO: Set the correct names of the ports for auto detection on Windows platform here
+         // TODO: Set the correct names of the ports for auto detection on Linux platform here
          // and uncomment this when port names are correct.
          // list.add(new String[]{"Input Port 0", "Input Port 1"}, new String[]{"Output Port 0", "Output Port 1"});
       }


### PR DESCRIPTION
This PR makes the controller auto-discoverable on Mac.

I found the port names via Java's builtin `javax.sound.midi.MidiSystem` class:

```java
MidiDevice.Info[] midiDeviceInfo = MidiSystem.getMidiDeviceInfo();
Arrays.stream(midiDeviceInfo)
    .map(d -> String.format(
        "Name: '%s' Vendor: '%s' Version; '%s' Description: '%s', Class: %s",
        d.getName(),
        d.getVendor(),
        d.getVersion(),
        d.getDescription(),
        d.getClass()))
    .forEach(System.out::println);
```

On my Mac (MacOS Sierra), the output looks like this:
```
Name: 'Gervill' Vendor: 'OpenJDK' Version; '1.0' Description: 'Software MIDI Synthesizer', Class: class com.sun.media.sound.SoftSynthesizer$Info
Name: ' Impulse ' Vendor: 'Focusrite A.E. Ltd' Version; 'Unknown version' Description: 'Impulse  Impulse ', Class: class com.sun.media.sound.MidiInDeviceProvider$MidiInDeviceInfo
Name: ' Impulse MIDI In ' Vendor: 'Focusrite A.E. Ltd' Version; 'Unknown version' Description: 'Impulse  Impulse MIDI In ', Class: class com.sun.media.sound.MidiInDeviceProvider$MidiInDeviceInfo
Name: ' Impulse ' Vendor: 'Focusrite A.E. Ltd' Version; 'Unknown version' Description: 'Impulse  Impulse ', Class: class com.sun.media.sound.MidiOutDeviceProvider$MidiOutDeviceInfo
Name: 'Real Time Sequencer' Vendor: 'Oracle Corporation' Version; 'Version 1.0' Description: 'Software sequencer', Class: class com.sun.media.sound.RealTimeSequencer$RealTimeSequencerInfo
```

My guess is that Bitwig uses `MidiSystem` to discover the ports. Whether that's true or not, the _descriptions_ reported by `MidiSystem` satisfy Bitwig auto-discovery. At least on my Mac.

Note that `MidiSystem` reports each Impulse port name as beginning and ending with a space. Those spaces are hard to see on the Bitwig Controllers page ;-)